### PR TITLE
Remove space from DMARC prefix

### DIFF
--- a/mailspoof/scanners.py
+++ b/mailspoof/scanners.py
@@ -210,7 +210,7 @@ class DMARCScan():
     """
 
     def __init__(self):
-        self.fetch = TXTFetch('v=DMARC1; ')
+        self.fetch = TXTFetch('v=DMARC1;')
 
     def __call__(self, domain):
         """


### PR DESCRIPTION
This space is not required by the spec, leading to some domains not having it. In such a case, mailspoof will report the domain as not having DMARC enabled.

References:
[DMARC RFC](https://tools.ietf.org/html/rfc7489#page-12) links to the [DKIM RFC](https://tools.ietf.org/html/rfc6376#page-12) for its format. This format specifies a semi-colon separated list. 