### PR TITLE
support nameserver definition from cli or from scan call

### DIFF
--- a/mailspoof/cli.py
+++ b/mailspoof/cli.py
@@ -21,11 +21,13 @@ def main():
         help='list of domains to check')
     parser.add_argument('-t', '--timeout', type=float, default='5',
                         help='timeout value for dns and http requests')
+    parser.add_argument('-s', '--nameserver', type=str, action="append",
+                        help="nameserver to use")
     parser.add_argument('-v', '--verbose', action='store_true',
                         help='enable verbose logging')
     parser.add_argument('--version', action='version',
         version=f'%(prog)s {__version__}')
-    
+
     args = parser.parse_args()
     scan = Scan()
 
@@ -53,7 +55,7 @@ def main():
     for domain in args.domains:
         results.append({
             'domain': domain,
-            'issues': scan(domain)
+            'issues': scan(domain, args.nameserver)
         })
 
     if args.output == '-':

--- a/mailspoof/scanners.py
+++ b/mailspoof/scanners.py
@@ -75,7 +75,7 @@ class SPFScan():
 
         # recursively count the number of lookups and get the domains used
         try:
-            included_domains, nb_lookups = self._get_include_domains(domain)
+            included_domains, nb_lookups = self._get_include_domains(domain, nameserver)
         except exceptions.SPFRecurse as exception:
             issue = ISSUES['SPF_RECURSE']
             issue['detail'] = issue['detail'].format(
@@ -124,7 +124,7 @@ class SPFScan():
 
         return issues
 
-    def _get_include_domains(self, domain):
+    def _get_include_domains(self, domain, nameserver):
         """
         Recursively goes through the domain's SPF record and included SPF
         records. Returns a tuple of the root domains encountered and
@@ -140,7 +140,7 @@ class SPFScan():
             nonlocal domains
 
             try:
-                spf_record = self.fetch(domain)
+                spf_record = self.fetch(domain, nameserver)
             except (ValueError, dns.resolver.NoAnswer, dns.resolver.NXDOMAIN,
                     dns.resolver.NoNameservers):
                 return


### PR DESCRIPTION
support custom nameserver, that can be defined using -s flag on commandline or when using mailspoof as library in the scan() call as argument.
defaults to None, standard dns.resolver behaviour should be respected